### PR TITLE
Add rides crud functionality

### DIFF
--- a/app/assets/javascripts/rides.coffee
+++ b/app/assets/javascripts/rides.coffee
@@ -1,0 +1,3 @@
+# Place all the behaviors and hooks related to the matching controller here.
+# All this logic will automatically be available in application.js.
+# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -108,6 +108,19 @@ input[type="email"] {
   }
 }
 
+textarea {
+  width: 100%;
+  height: 50px;
+  outline: none;
+  border-width: 0 0 3px 0;
+  border-color: rgba(127, 127, 127, 0.3);
+  font-size: 18px;
+  color: rgb(44, 44, 44);
+  &:focus {
+    border-color: $app-blue;
+  }
+}
+
 /************************************
               Tables
 *************************************/

--- a/app/assets/stylesheets/rides.scss
+++ b/app/assets/stylesheets/rides.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the Rides controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -25,7 +25,35 @@ class ApplicationController < ActionController::Base
     end
   end
 
-  def owner_or_admin?
-    @requester_is_admin = current_user.is_admin
+  def create_resource(resource)
+    respond_to do |format|
+      if resource.save
+        format.html { redirect_to resource, notice: "#{resource.class} was successfully created." }
+        format.json { render :show, status: :created, location: resource }
+      else
+        format.html { render :new }
+        format.json { render json: resource.errors, status: :unprocessable_entity }
+      end
+    end
+  end
+
+  def update_resource(resource, params)
+    respond_to do |format|
+      if resource.update(params)
+        format.html { redirect_to resource, notice: "#{resource.class} was successfully updated." }
+        format.json { render :show, status: :ok, location: resource }
+      else
+        format.html { render :edit }
+        format.json { render json: resource.errors, status: :unprocessable_entity }
+      end
+    end
+  end
+
+  def destroy_resource(resource, redirect_route)
+    resource.destroy
+    respond_to do |format|
+      format.html { redirect_to redirect_route, notice: "#{resource.class} was successfully destroyed." }
+      format.json { head :no_content }
+    end
   end
 end

--- a/app/controllers/rides_controller.rb
+++ b/app/controllers/rides_controller.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+class RidesController < ApplicationController
+  before_action :set_ride, only: %i[show edit update destroy]
+
+  # GET /rides
+  # GET /rides.json
+  def index
+    @rides = current_user.is_admin ? Ride.all : current_user.rides
+  end
+
+  # GET /rides/1
+  # GET /rides/1.json
+  def show; end
+
+  # GET /rides/new
+  def new
+    @ride = Ride.new
+  end
+
+  # GET /rides/1/edit
+  def edit; end
+
+  # POST /rides
+  # POST /rides.json
+  def create
+    @ride = Ride.new(ride_params)
+    create_resource @ride
+  end
+
+  # PATCH/PUT /rides/1
+  # PATCH/PUT /rides/1.json
+  def update
+    update_resource @ride, ride_params
+  end
+
+  # DELETE /rides/1
+  # DELETE /rides/1.json
+  def destroy
+    destroy_resource @ride, rides_url
+  end
+
+  private
+
+  # Use callbacks to share common setup or constraints between actions.
+  def set_ride
+    @ride = if current_user.is_admin
+              Ride.find(params[:id])
+            else
+              current_user.rides.find(params[:id])
+            end
+
+    @ride = Ride.find(params[:id])
+  end
+
+  # Never trust parameters from the scary internet, only allow the white list through.
+  def ride_params
+    params.require(:ride).permit(:origin, :destination, :departure_date, :departure_time, :description, :vehicle_id)
+  end
+end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -17,11 +17,7 @@ class UsersController < ApplicationController
   # DELETE /users/1
   # DELETE /users/1.json
   def destroy
-    @user.destroy
-    respond_to do |format|
-      format.html { redirect_to users_url, notice: 'User was successfully destroyed.' }
-      format.json { head :no_content }
-    end
+    destroy_resource @user, users_url
   end
 
   private

--- a/app/controllers/vehicles_controller.rb
+++ b/app/controllers/vehicles_controller.rb
@@ -1,13 +1,12 @@
 # frozen_string_literal: true
 
 class VehiclesController < ApplicationController
-  before_action :owner_or_admin?
   before_action :set_vehicle, only: %i[show edit update destroy]
 
   # GET /vehicles
   # GET /vehicles.json
   def index
-    @vehicles = @requester_is_admin ? Vehicle.all : current_user.vehicles
+    @vehicles = current_user.is_admin ? Vehicle.all : current_user.vehicles
   end
 
   # GET /vehicles/1
@@ -27,46 +26,26 @@ class VehiclesController < ApplicationController
   def create
     @vehicle = current_user.create_vehicle(vehicle_params)
 
-    respond_to do |format|
-      if @vehicle.save
-        format.html { redirect_to @vehicle, notice: 'Vehicle was successfully created.' }
-        format.json { render :show, status: :created, location: @vehicle }
-      else
-        format.html { render :new }
-        format.json { render json: @vehicle.errors, status: :unprocessable_entity }
-      end
-    end
+    create_resource @vehicle
   end
 
   # PATCH/PUT /vehicles/1
   # PATCH/PUT /vehicles/1.json
   def update
-    respond_to do |format|
-      if @vehicle.update(vehicle_params)
-        format.html { redirect_to @vehicle, notice: 'Vehicle was successfully updated.' }
-        format.json { render :show, status: :ok, location: @vehicle }
-      else
-        format.html { render :edit }
-        format.json { render json: @vehicle.errors, status: :unprocessable_entity }
-      end
-    end
+    update_resource @vehicle, vehicle_params
   end
 
   # DELETE /vehicles/1
   # DELETE /vehicles/1.json
   def destroy
-    @vehicle.destroy
-    respond_to do |format|
-      format.html { redirect_to vehicles_url, notice: 'Vehicle was successfully destroyed.' }
-      format.json { head :no_content }
-    end
+    destroy_resource @vehicle, vehicles_url
   end
 
   private
 
   # Use callbacks to share common setup or constraints between actions.
   def set_vehicle
-    @vehicle = if @requester_is_admin
+    @vehicle = if current_user.is_admin
                  Vehicle.find(params[:id])
                else
                  current_user.vehicles.find(params[:id])

--- a/app/helpers/rides_helper.rb
+++ b/app/helpers/rides_helper.rb
@@ -1,0 +1,2 @@
+module RidesHelper
+end

--- a/app/models/ride.rb
+++ b/app/models/ride.rb
@@ -1,0 +1,6 @@
+class Ride < ApplicationRecord
+  validates :origin, :destination, :departure_date, :departure_time,
+            :description, presence: true
+
+  belongs_to :vehicle
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class User < ApplicationRecord
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable and :omniauthable
@@ -6,7 +8,17 @@ class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :trackable, :validatable
 
-  has_many :vehicles
+  has_many :vehicles, dependent: :destroy
+  has_many :rides, through: :vehicles
+
+  def vehicles_hash
+    vehicles_hash = {}
+    vehicles.each do |vehicle|
+      vehicles_hash[vehicle.vehicle_model] = vehicle.id
+    end
+
+    vehicles_hash
+  end
 
   def full_name
     "#{first_name} #{last_name}"

--- a/app/models/vehicle.rb
+++ b/app/models/vehicle.rb
@@ -3,4 +3,5 @@ class Vehicle < ApplicationRecord
   validates :license_plate, uniqueness: true
 
   belongs_to :user
+  has_many :rides, dependent: :nullify
 end

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -33,5 +33,6 @@
       <div class="links">
         <%= render "devise/shared/links" %>
       </div>
+    </div>
   </div>
 </div>

--- a/app/views/rides/_form.html.erb
+++ b/app/views/rides/_form.html.erb
@@ -1,0 +1,47 @@
+<%= form_with(model: ride, local: true) do |form| %>
+  <% if ride.errors.any? %>
+    <div id="error_explanation">
+      <h2><%= pluralize(ride.errors.count, "error") %> prohibited this ride from being saved:</h2>
+
+      <ul>
+      <% ride.errors.full_messages.each do |message| %>
+        <li><%= message %></li>
+      <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <div class="field">
+    <%= form.label :origin %>
+    <%= form.text_field :origin %>
+  </div>
+
+  <div class="field">
+    <%= form.label :destination %>
+    <%= form.text_field :destination %>
+  </div>
+
+  <div class="field">
+    <%= form.label :departure_date %>
+    <%= form.date_select :departure_date %>
+  </div>
+
+  <div class="field">
+    <%= form.label :departure_time %>
+    <%= form.time_select :departure_time %>
+  </div>
+
+  <div class="field">
+    <%= form.label :description %>
+    <%= form.text_area :description %>
+  </div>
+
+  <div class="field">
+    <%= form.label :vehicle_id %>
+    <%= form.select :vehicle_id, current_user.vehicles_hash, id: :ride_vehicles, prompt: 'Select a vehicle' %>
+  </div>
+
+  <div class="actions">
+    <%= form.submit %>
+  </div>
+<% end %>

--- a/app/views/rides/_ride.json.jbuilder
+++ b/app/views/rides/_ride.json.jbuilder
@@ -1,0 +1,2 @@
+json.extract! ride, :id, :origin, :destination, :departure_date, :departure_time, :description, :vehicle_id, :created_at, :updated_at
+json.url ride_url(ride, format: :json)

--- a/app/views/rides/edit.html.erb
+++ b/app/views/rides/edit.html.erb
@@ -1,0 +1,6 @@
+<h1>Editing Ride</h1>
+
+<%= render 'form', ride: @ride %>
+
+<%= link_to 'Show', @ride %> |
+<%= link_to 'Back', rides_path %>

--- a/app/views/rides/index.html.erb
+++ b/app/views/rides/index.html.erb
@@ -1,0 +1,33 @@
+<p id="notice"><%= notice %></p>
+
+<h1>Rides</h1>
+
+<table class="table">
+  <thead>
+    <tr>
+      <th>Origin</th>
+      <th>Destination</th>
+      <th>Departure date</th>
+      <th>Departure time</th>
+      <th colspan="3"></th>
+    </tr>
+  </thead>
+
+  <tbody>
+    <% @rides.each do |ride| %>
+      <tr>
+        <td><%= ride.origin %></td>
+        <td><%= ride.destination %></td>
+        <td><%= ride.departure_date %></td>
+        <td><%= ride.departure_time %></td>
+        <td><%= link_to 'Show', ride %></td>
+        <td><%= link_to 'Edit', edit_ride_path(ride) %></td>
+        <td><%= link_to 'Destroy', ride, method: :delete, data: { confirm: 'Are you sure?' } %></td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>
+
+<br>
+
+<%= link_to 'New Ride', new_ride_path %>

--- a/app/views/rides/index.json.jbuilder
+++ b/app/views/rides/index.json.jbuilder
@@ -1,0 +1,1 @@
+json.array! @rides, partial: 'rides/ride', as: :ride

--- a/app/views/rides/new.html.erb
+++ b/app/views/rides/new.html.erb
@@ -1,0 +1,5 @@
+<h1>New Ride</h1>
+
+<%= render 'form', ride: @ride %>
+
+<%= link_to 'Back', rides_path %>

--- a/app/views/rides/show.html.erb
+++ b/app/views/rides/show.html.erb
@@ -1,0 +1,44 @@
+<p id="notice"><%= notice %></p>
+
+<p>
+  <strong>Origin:</strong>
+  <%= @ride.origin %>
+</p>
+
+<p>
+  <strong>Destination:</strong>
+  <%= @ride.destination %>
+</p>
+
+<p>
+  <strong>Departure date:</strong>
+  <%= @ride.departure_date %>
+</p>
+
+<p>
+  <strong>Departure time:</strong>
+  <%= @ride.departure_time %>
+</p>
+
+<p>
+  <strong>Description:</strong>
+  <%= @ride.description %>
+</p>
+
+<p>
+  <strong>Vehicle:</strong>
+  <%= @ride.vehicle.vehicle_model %>
+</p>
+
+<p>
+  <strong>Vehicle License Plates:</strong>
+  <%= @ride.vehicle.license_plate %>
+</p>
+
+<p>
+  <strong>User Name:</strong>
+  <%= @ride.vehicle.user&.full_name %>
+</p>
+
+<%= link_to 'Edit', edit_ride_path(@ride) %> |
+<%= link_to 'Back', rides_path %>

--- a/app/views/rides/show.json.jbuilder
+++ b/app/views/rides/show.json.jbuilder
@@ -1,0 +1,1 @@
+json.partial! "rides/ride", ride: @ride

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
+  resources :rides
   resources :vehicles
   root 'home#index', as: 'home_index'
 

--- a/db/migrate/20180813202536_create_rides.rb
+++ b/db/migrate/20180813202536_create_rides.rb
@@ -1,0 +1,14 @@
+class CreateRides < ActiveRecord::Migration[5.2]
+  def change
+    create_table :rides do |t|
+      t.string :origin
+      t.string :destination
+      t.date :departure_date
+      t.time :departure_time
+      t.text :description
+      t.references :vehicle, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,22 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_08_13_123645) do
+ActiveRecord::Schema.define(version: 2018_08_13_202536) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "rides", force: :cascade do |t|
+    t.string "origin"
+    t.string "destination"
+    t.date "departure_date"
+    t.time "departure_time"
+    t.text "description"
+    t.bigint "vehicle_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["vehicle_id"], name: "index_rides_on_vehicle_id"
+  end
 
   create_table "users", force: :cascade do |t|
     t.string "first_name", null: false
@@ -45,5 +57,6 @@ ActiveRecord::Schema.define(version: 2018_08_13_123645) do
     t.index ["user_id"], name: "index_vehicles_on_user_id"
   end
 
+  add_foreign_key "rides", "vehicles"
   add_foreign_key "vehicles", "users"
 end

--- a/test/controllers/rides_controller_test.rb
+++ b/test/controllers/rides_controller_test.rb
@@ -1,0 +1,53 @@
+require 'test_helper'
+
+class RidesControllerTest < ActionDispatch::IntegrationTest
+
+  include Devise::Test::IntegrationHelpers
+
+  setup do
+    @user = users(:one)
+    sign_in @user
+    @ride = rides(:one)
+  end
+
+  test "should get index" do
+    get rides_url
+    assert_response :success
+  end
+
+  test "should get new" do
+    get new_ride_url
+    assert_response :success
+  end
+
+  test "should create ride" do
+    assert_difference('Ride.count') do
+      post rides_url, params: { ride: { departure_date: @ride.departure_date, departure_time: @ride.departure_time, description: @ride.description, destination: @ride.destination, origin: @ride.origin, vehicle_id: @ride.vehicle_id } }
+    end
+
+    assert_redirected_to ride_url(Ride.last)
+  end
+
+  test "should show ride" do
+    get ride_url(@ride)
+    assert_response :success
+  end
+
+  test "should get edit" do
+    get edit_ride_url(@ride)
+    assert_response :success
+  end
+
+  test "should update ride" do
+    patch ride_url(@ride), params: { ride: { departure_date: @ride.departure_date, departure_time: @ride.departure_time, description: @ride.description, destination: @ride.destination, origin: @ride.origin, vehicle_id: @ride.vehicle_id } }
+    assert_redirected_to ride_url(@ride)
+  end
+
+  test "should destroy ride" do
+    assert_difference('Ride.count', -1) do
+      delete ride_url(@ride)
+    end
+
+    assert_redirected_to rides_url
+  end
+end

--- a/test/fixtures/rides.yml
+++ b/test/fixtures/rides.yml
@@ -1,0 +1,17 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  origin: MyString
+  destination: MyString
+  departure_date: 2018-08-13
+  departure_time: 2018-08-13 23:25:36
+  description: MyText
+  vehicle: one
+
+two:
+  origin: MyString
+  destination: MyString
+  departure_date: 2018-08-13
+  departure_time: 2018-08-13 23:25:36
+  description: MyText
+  vehicle: two

--- a/test/fixtures/vehicles.yml
+++ b/test/fixtures/vehicles.yml
@@ -4,8 +4,10 @@ one:
   vehicle_model: Vehicle One
   license_plate: VHL 100A
   capacity: 4
+  user_id: 1
 
 two:
   vehicle_model: Vehicle Two
   license_plate: VHL 200A
   capacity: 4
+  user_id: 2

--- a/test/models/ride_test.rb
+++ b/test/models/ride_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class RideTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/system/rides_test.rb
+++ b/test/system/rides_test.rb
@@ -1,0 +1,53 @@
+require "application_system_test_case"
+
+class RidesTest < ApplicationSystemTestCase
+  setup do
+    @ride = rides(:one)
+  end
+
+  test "visiting the index" do
+    visit rides_url
+    assert_selector "h1", text: "Rides"
+  end
+
+  test "creating a Ride" do
+    visit rides_url
+    click_on "New Ride"
+
+    fill_in "Departure Date", with: @ride.departure_date
+    fill_in "Departure Time", with: @ride.departure_time
+    fill_in "Description", with: @ride.description
+    fill_in "Destination", with: @ride.destination
+    fill_in "Origin", with: @ride.origin
+    fill_in "Vehicle", with: @ride.vehicle_id
+    click_on "Create Ride"
+
+    assert_text "Ride was successfully created"
+    click_on "Back"
+  end
+
+  test "updating a Ride" do
+    visit rides_url
+    click_on "Edit", match: :first
+
+    fill_in "Departure Date", with: @ride.departure_date
+    fill_in "Departure Time", with: @ride.departure_time
+    fill_in "Description", with: @ride.description
+    fill_in "Destination", with: @ride.destination
+    fill_in "Origin", with: @ride.origin
+    fill_in "Vehicle", with: @ride.vehicle_id
+    click_on "Update Ride"
+
+    assert_text "Ride was successfully updated"
+    click_on "Back"
+  end
+
+  test "destroying a Ride" do
+    visit rides_url
+    page.accept_confirm do
+      click_on "Destroy", match: :first
+    end
+
+    assert_text "Ride was successfully destroyed"
+  end
+end


### PR DESCRIPTION
### What does this pull request do?

This pull request adds functionality for the rides resource for both the admin and the users. It gives users the ability to add rides, delete rides and update them, but limited to only those they created themselves. It also adds admin privileges to rides crud, which gives admin all abilities with vehicles.

### Task accomplished
I added a controller for the rides which handles the crud. I also added a model which gives the vehicles restrictions for the presence of certain fields and gives ORM integration access to the database. I have included migrations for creating the database tables.

Within the controller, I have added restrictions that prevent a user from accessing other users rides unless they are admins.

I also added tests for this functionality.

### Relevant pivotal stories.

[#159695901](https://www.pivotaltracker.com/story/show/159695901), [#159696296](https://www.pivotaltracker.com/story/show/159696296), [#159696263](https://www.pivotaltracker.com/story/show/159696263), [#159696675](https://www.pivotaltracker.com/story/show/159696675)